### PR TITLE
fix : repair monitoring statistics for MetricCollectors

### DIFF
--- a/src/runtime/collector/realtime/picker/worker.rs
+++ b/src/runtime/collector/realtime/picker/worker.rs
@@ -225,6 +225,11 @@ impl SourceWorker {
                 }
                 self.picker.finish_burst_round();
                 total_round = total_round.merge(one_round);
+                stat_ext
+                    .send_stat(&self.mon_s)
+                    .await
+                    .owe_sys()
+                    .want("mon-stat")?;
                 if total_round.is_stop() {
                     break 'main;
                 }
@@ -235,6 +240,7 @@ impl SourceWorker {
             }
             if last_stat_tick.elapsed() >= stat_interval {
                 // 仅周期性打印 pending 水位，以降低日志噪声
+                last_stat_tick = Instant::now();
                 info_mtrc!(
                     "{} pick-pending cnt: {}",
                     rt_name,
@@ -245,7 +251,6 @@ impl SourceWorker {
                     .await
                     .owe_sys()
                     .want("mon-stat")?;
-                last_stat_tick = Instant::now();
             }
             // 外层根据“限速/等待”计算应休眠的时间，避免在数据路径处直接 sleep
             let sleep_dur = self.calc_sleep_duration(&total_round, &task_ctrl);

--- a/src/runtime/parser/act_parser.rs
+++ b/src/runtime/parser/act_parser.rs
@@ -73,6 +73,7 @@ impl ActParser {
         );
         let mut stat_tick = interval(Duration::from_millis(STAT_INTERVAL_MS as u64));
         stat_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        let mut has_record = false;
         loop {
             tokio::select! {
                Some(mut batch)  = dat_recv.recv() => {
@@ -91,6 +92,7 @@ impl ActParser {
                    }
                    // 正常执行解析+下发
                    self.engine.proc_batch(batch, &setting).await?;
+                    has_record=true;
                }
                Ok(cmd) =  run_ctrl.cmds_sub_mut().recv() => { run_ctrl.update_cmd(cmd); }
               _ = sleep(Duration::from_millis(50)) => {
@@ -99,7 +101,10 @@ impl ActParser {
                   if run_ctrl.is_stop() { break; }
               }
               _ = stat_tick.tick() => {
-                  self.engine.send_stat(mon_send).await?;
+                if has_record {
+                    has_record=false;
+                    self.engine.send_stat(mon_send).await?;
+                }
               }
             }
         }

--- a/src/runtime/sink/act_sink.rs
+++ b/src/runtime/sink/act_sink.rs
@@ -2,6 +2,8 @@ use crate::facade::test_helpers::SinkTerminal;
 use crate::resources::ResManager;
 use crate::resources::SinkID;
 use crate::runtime::prelude::*;
+use tokio::time::MissedTickBehavior;
+use tokio::time::interval;
 use wp_connector_api::AsyncCtrl;
 use wp_data_model::cache::FieldQueryCache;
 
@@ -18,7 +20,7 @@ use crate::sinks::{
     SinkPackage,
 };
 use crate::sinks::{InfraSinkAgent, SinkGroupAgent};
-use crate::stat::MonSend;
+use crate::stat::{MonSend, STAT_INTERVAL_MS};
 use orion_error::ContextRecord;
 use orion_error::OperationContext;
 use orion_overload::append::Appendable;
@@ -148,6 +150,10 @@ impl SinkWork {
         let sink_name = sink.get_name().to_string();
         ctx.record("name", name);
         let mut drain_state = DrainState::new(1);
+
+        let mut stat_tick = interval(Duration::from_millis(STAT_INTERVAL_MS as u64));
+        stat_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        let mut has_record = false;
         loop {
             tokio::select! {
                 pkg_opt = sink.get_dat_r_mut().recv() => {
@@ -161,6 +167,7 @@ impl SinkWork {
                             } else {
                                 run_ctrl.rec_task_idle();
                             }
+                            has_record=true;
                         }
                         None => {
                             match drain_state.channel_closed_is_drained() {
@@ -203,7 +210,20 @@ impl SinkWork {
                 Some(h) = fix_sink_r.recv(), if !drain_state.is_draining() => {
                     Self::proc_fix_ex(h,&mut sink,  &mon_send).await?;
                 }
+                _ = stat_tick.tick() => {
+                    if has_record {
+                        has_record=false;
+                        let sinks=sink.get_sinks_mut();
+                        for s in sinks.iter_mut() {
+                            s.send_stat(&mon_send).await?;
+                        }
+                    }
+                }
             }
+        }
+        let sinks = sink.get_sinks_mut();
+        for s in sinks.iter_mut() {
+            s.send_stat(&mon_send).await?;
         }
         sink.proc_end().await?;
         info_ctrl!("{} async sinks proc end", sink_name);
@@ -458,6 +478,10 @@ impl ActSink {
     ) -> anyhow::Result<()> {
         info_data!("async sinks proc start");
         let mut run_ctrl = TaskController::new("sink", self.cmd_r.clone(), None);
+
+        let mut stat_tick = interval(Duration::from_millis(STAT_INTERVAL_MS as u64));
+        stat_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        let mut has_record = false;
         loop {
             tokio::select! {
                 res = dat_r.recv() => {
@@ -488,6 +512,12 @@ impl ActSink {
                         break;
                     }
                 }
+                _ = stat_tick.tick() => {
+                    if has_record {
+                        has_record=false;
+                        sink_rt.send_stat(&self.mon_s).await?;
+                    }
+                }
             }
         }
         info_data!(
@@ -495,6 +525,7 @@ impl ActSink {
             run_ctrl.total_count()
         );
         sink_rt.primary.stop().await?;
+        sink_rt.send_stat(&self.mon_s).await?;
         //let snap = sink_rt.stat.swap_snap();
         //self.mon_s.send(StatSlices::Sink(snap)).await?;
 

--- a/src/sinks/routing/dispatcher/mod.rs
+++ b/src/sinks/routing/dispatcher/mod.rs
@@ -74,6 +74,9 @@ impl SinkDispatcher {
     pub fn get_dat_r_mut(&mut self) -> &mut SinkDatYReceiver {
         &mut self.dat_r
     }
+    pub fn get_sinks_mut(&mut self) -> &mut Vec<SinkRuntime> {
+        &mut self.sinks
+    }
     pub fn close_channel(&mut self) {
         self.dat_r.close();
     }


### PR DESCRIPTION
This PR fixes inaccuracies in monitoring statistics within the log distribution pipeline (source → parse → sink).

* **Sink statistics issue**
  Previously, sink metrics were updated only after sink operations completed. Due to a rate limiter in the statistics logic, the final update could be dropped if it was rate-limited, leading to under-reported sink metrics.
  This is fixed by changing sink statistics collection from post-operation updates to periodic reporting.

* **Source statistics lower than parse and sink**
  When parsing is fast, source metrics are recorded earlier than parse and sink metrics, and the time gap between these updates can cause source counts to appear smaller.
  The current solution increases the collection frequency of source statistics to reduce this time skew.
