### PR TITLE
fix : repair monitoring statistics and examples for MetricCollectors

### DIFF
--- a/src/runtime/collector/realtime/picker/worker.rs
+++ b/src/runtime/collector/realtime/picker/worker.rs
@@ -235,6 +235,7 @@ impl SourceWorker {
             }
             if last_stat_tick.elapsed() >= stat_interval {
                 // 仅周期性打印 pending 水位，以降低日志噪声
+                last_stat_tick = Instant::now();
                 info_mtrc!(
                     "{} pick-pending cnt: {}",
                     rt_name,
@@ -245,7 +246,6 @@ impl SourceWorker {
                     .await
                     .owe_sys()
                     .want("mon-stat")?;
-                last_stat_tick = Instant::now();
             }
             // 外层根据“限速/等待”计算应休眠的时间，避免在数据路径处直接 sleep
             let sleep_dur = self.calc_sleep_duration(&total_round, &task_ctrl);

--- a/src/runtime/generator/speed/controller.rs
+++ b/src/runtime/generator/speed/controller.rs
@@ -370,7 +370,7 @@ mod tests {
     #[test]
     fn test_stepped_loop_forever() {
         let mut ctrl = DynamicSpeedController::new(SpeedProfile::Stepped {
-            steps: vec![(0.3, 1000), (0.3, 2000)],
+            steps: vec![(1.0, 1000), (1.0, 2000)],
             loop_forever: true,
         });
 
@@ -378,11 +378,11 @@ mod tests {
         assert_eq!(ctrl.current_speed(), 1000);
 
         // 等待进入第二阶段
-        sleep(Duration::from_millis(350));
+        sleep(Duration::from_millis(1000));
         assert_eq!(ctrl.current_speed(), 2000);
 
         // 循环回到第一阶段
-        sleep(Duration::from_millis(350));
+        sleep(Duration::from_millis(1000));
         assert_eq!(ctrl.current_speed(), 1000);
     }
 

--- a/src/sinks/routing/dispatcher/mod.rs
+++ b/src/sinks/routing/dispatcher/mod.rs
@@ -74,6 +74,9 @@ impl SinkDispatcher {
     pub fn get_dat_r_mut(&mut self) -> &mut SinkDatYReceiver {
         &mut self.dat_r
     }
+    pub fn get_sinks_mut(&mut self) -> &mut Vec<SinkRuntime> {
+        &mut self.sinks
+    }
     pub fn close_channel(&mut self) {
         self.dat_r.close();
     }


### PR DESCRIPTION
This PR fixes inaccuracies in monitoring statistics within the log distribution pipeline (source → parse → sink).

* **Sink statistics issue**
  Previously, sink metrics were updated only after sink operations completed. Due to a rate limiter in the statistics logic, the final update could be dropped if it was rate-limited, leading to under-reported sink metrics.
  This is fixed by changing sink statistics collection from post-operation updates to periodic reporting.

* **Source statistics lower than parse and sink**
  When parsing is fast, source metrics are recorded earlier than parse and sink metrics, and the time gap between these updates can cause source counts to appear smaller.
  The current solution increases the collection frequency of source statistics to reduce this time skew.
