### PR TITLE
Knowledge base optimization

### DIFF
--- a/crates/wp-oml/src/core/evaluator/extract/operations/other.rs
+++ b/crates/wp-oml/src/core/evaluator/extract/operations/other.rs
@@ -6,7 +6,7 @@ use crate::language::GenericAccessor;
 use crate::language::{GenericBinding, NestedBinding, SingleEvalExp};
 use async_trait::async_trait;
 use wp_knowledge::cache::FieldQueryCache;
-use wp_model_core::model::{DataField, DataRecord, DataType, FieldStorage};
+use wp_model_core::model::{DataField, DataRecord, DataType, FieldStorage, Value};
 
 #[async_trait]
 impl AsyncExpEvaluator for SingleEvalExp {
@@ -20,6 +20,9 @@ impl AsyncExpEvaluator for SingleEvalExp {
             let obj: Vec<DataField> = self.eval_way().extract_more_async(src, dst, cache).await;
             for i in 0..self.target().len() {
                 if let (Some(target), Some(mut v)) = (self.target().get(i), obj.get(i).cloned()) {
+                    if matches!(v.get_value(), Value::Null) {
+                        continue;
+                    }
                     if let Some(name) = target.name() {
                         v.set_name(name.clone());
                     }
@@ -37,10 +40,16 @@ impl AsyncExpEvaluator for SingleEvalExp {
                 target.data_type() != storage.get_meta() && target.data_type() != &DataType::Auto;
 
             if storage.is_shared() && !needs_conversion {
+                if matches!(storage.as_field().get_value(), Value::Null) {
+                    return;
+                }
                 storage.set_name(target.safe_name());
                 dst.items.push(storage);
             } else {
                 let mut field = storage.into_owned();
+                if matches!(field.get_value(), Value::Null) {
+                    return;
+                }
                 field.set_name(target.safe_name());
 
                 if needs_conversion {

--- a/crates/wp-oml/src/core/evaluator/query/sql.rs
+++ b/crates/wp-oml/src/core/evaluator/query/sql.rs
@@ -64,7 +64,7 @@ fn collect_sql_params(
     query: &SqlQuery,
     src: &mut DataRecordRef<'_>,
     dst: &mut DataRecord,
-) -> (String, DataField, Vec<DataField>) {
+) -> (String, DataField, Vec<DataField>, bool) {
     let mut params = Vec::with_capacity(5);
     let target = EvaluationTarget::auto_default();
     let sql = query.oml_sql().to_string();
@@ -92,7 +92,11 @@ fn collect_sql_params(
         debug_kdb!("[param] :{} = {}", v, preview);
     }
     let md5 = DataField::from_chars("sql".to_string(), query.sql_md5().clone());
-    (sql, md5, params)
+    let all_params_null = !params.is_empty()
+        && params
+            .iter()
+            .all(|param| matches!(param.get_value(), Value::Null));
+    (sql, md5, params, all_params_null)
 }
 
 #[allow(dead_code)]
@@ -124,7 +128,11 @@ impl SqlQuery {
         dst: &mut DataRecord,
         cache: &mut FieldQueryCache,
     ) -> Vec<DataField> {
-        let (sql, md5, params) = collect_sql_params(self, src, dst);
+        let (sql, md5, params, all_params_null) = collect_sql_params(self, src, dst);
+        if all_params_null {
+            debug_kdb!("[sql] skip query because all params are null");
+            return Vec::new();
+        }
 
         match params.len() {
             0 => {
@@ -277,7 +285,11 @@ impl AsyncFieldExtractor for SqlQuery {
         dst: &mut DataRecord,
         cache: &mut FieldQueryCache,
     ) -> Vec<DataField> {
-        let (sql, md5, params) = collect_sql_params(self, src, dst);
+        let (sql, md5, params, all_params_null) = collect_sql_params(self, src, dst);
+        if all_params_null {
+            debug_kdb!("[sql] skip async query because all params are null");
+            return Vec::new();
+        }
 
         match params.len() {
             0 => {
@@ -565,6 +577,34 @@ mod tests {
         let query = create_test_query(
             "SELECT * FROM test WHERE id IN (:p1, :p2, :p3, :p4, :p5, :p6)",
             params,
+        );
+
+        let result = query.extract_more(
+            &mut DataRecordRef::from(&DataRecord::default()),
+            &mut DataRecord::default(),
+            cache,
+        );
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_all_null_params_skip_query() {
+        ensure_provider();
+        let cache = &mut FieldQueryCache::default();
+
+        let query = create_test_query(
+            "SELECT * FROM table_that_should_not_be_queried WHERE id = :id AND name = :name",
+            vec![
+                (
+                    "id",
+                    DataField::new(DataType::default(), "id".to_string(), Value::Null),
+                ),
+                (
+                    "name",
+                    DataField::new(DataType::default(), "name".to_string(), Value::Null),
+                ),
+            ],
         );
 
         let result = query.extract_more(

--- a/crates/wp-oml/src/parser/sql_prm.rs
+++ b/crates/wp-oml/src/parser/sql_prm.rs
@@ -789,6 +789,34 @@ zone : chars = select zone from zone where ip_start_int <= ip4_int(read(src_ip))
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn test_sql_aggregate_null_is_not_emitted() -> ModalResult<()> {
+        let db = MemDB::global();
+        db.table_create("CREATE TABLE IF NOT EXISTS asset_data (asset TEXT, ip TEXT)")
+            .assert();
+        db.execute("DELETE FROM asset_data").assert();
+        db.execute("INSERT INTO asset_data (asset, ip) VALUES ('host-a', '10.0.0.1')")
+            .assert();
+        let _ = kdb::init_mem_provider(db);
+
+        let mut conf = r#"
+name : test
+---
+test_list : chars = select group_concat(distinct asset) from asset_data where ip in(@sip, @dip) ;
+        "#;
+        let model = oml_parse_raw(&mut conf).await.assert();
+
+        let src = DataRecord::from(vec![
+            FieldStorage::from_owned(DataField::from_chars("sip", "192.0.2.10")),
+            FieldStorage::from_owned(DataField::from_chars("dip", "192.0.2.11")),
+        ]);
+        let cache = &mut FieldQueryCache::default();
+        let out = model.transform_async(src, cache).await;
+
+        assert!(out.get2("test_list").is_none(), "out={out:?}");
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn test_object_async_uses_nested_accessors() -> ModalResult<()> {
         let mut conf = r#"
 name : test


### PR DESCRIPTION
**背景**
在 OML SQL enrichment 场景中，聚合查询和缺失参数会带来两个问题：

- `string_agg` / `group_concat` 等聚合函数在无匹配行时会返回 `NULL`，当前会被写入最终结果，形成 `field: null`
- 当 SQL 的所有动态参数都解析为 `NULL` 时，仍会继续访问 knowledge provider / 数据库，容易产生大量无意义查询和错误日志

**修改内容**
1. 跳过最终结果中的 `NULL` 字段
- 在 `SingleEvalExp::eval_proc_async` 写入 `dst.items` 前增加 `Value::Null` 判断
- batch 分支和单值分支都统一跳过 `NULL` 结果
- 聚合 SQL 无命中时不再输出 `test_list: null`

2. SQL 全空参数短路
- 在 `collect_sql_params` 中识别动态 SQL 参数是否全部为 `NULL`
- 如果存在动态参数且全部为 `NULL`，同步和异步 SQL 执行入口直接返回空结果
- 这种情况下不会访问 knowledge provider，也不会执行数据库查询
- 无动态参数的 SQL 仍会正常执行

3. 补充回归测试
- 新增测试覆盖聚合查询无命中时不输出目标字段
- 新增测试覆盖所有 SQL 动态参数为 `NULL` 时跳过查询
- 保留已有 SQL enrichment 路径的回归验证

**主要影响文件**
- `crates/wp-oml/src/core/evaluator/extract/operations/other.rs`
- `crates/wp-oml/src/core/evaluator/query/sql.rs`
- `crates/wp-oml/src/parser/sql_prm.rs`

**关联 Issue**
- https://github.com/wp-labs/wp-motor/issues/90
- https://github.com/wp-labs/wp-motor/issues/91