### PR TITLE
Enhance OML knowledge SQL handling and prefer local sqlite authority

### DIFF
--- a/crates/wp-oml/src/core/evaluator/mod.rs
+++ b/crates/wp-oml/src/core/evaluator/mod.rs
@@ -3,5 +3,5 @@ pub(crate) mod traits;
 
 mod extract;
 mod functions;
-mod query;
+pub mod query;
 pub mod transform; // 公开 transform 模块

--- a/crates/wp-oml/src/core/evaluator/query/mod.rs
+++ b/crates/wp-oml/src/core/evaluator/query/mod.rs
@@ -1,2 +1,2 @@
 //mod shlib;
-mod sql;
+pub mod sql;

--- a/crates/wp-oml/src/core/evaluator/query/sql.rs
+++ b/crates/wp-oml/src/core/evaluator/query/sql.rs
@@ -2,7 +2,10 @@ use crate::core::prelude::*;
 use crate::language::EvaluationTarget;
 use crate::language::SqlQuery;
 use async_trait::async_trait;
+use std::collections::HashSet;
+use std::sync::{OnceLock, RwLock};
 use wp_knowledge::facade as kdb;
+use wp_know::mem::thread_clone::ThreadClonedMDB;
 use wp_model_core::model::FieldStorage;
 use wp_model_core::model::{DataType, Value};
 
@@ -11,6 +14,57 @@ use crate::core::AsyncFieldExtractor;
 // SQL evaluator already places the SQL md5 into c_params[0], so a separate scope hash
 // would only duplicate the same partitioning work on the local-cache hot path.
 const INLINE_SQL_LOCAL_CACHE_SCOPE: u64 = 0;
+
+#[derive(Clone, Debug)]
+struct LocalSqliteRoute {
+    authority_uri: String,
+    tables: HashSet<String>,
+}
+
+fn local_sqlite_route() -> &'static RwLock<Option<LocalSqliteRoute>> {
+    static ROUTE: OnceLock<RwLock<Option<LocalSqliteRoute>>> = OnceLock::new();
+    ROUTE.get_or_init(|| RwLock::new(None))
+}
+
+pub fn set_local_sqlite_priority_route(authority_uri: String, tables: Vec<String>) {
+    let route = LocalSqliteRoute {
+        authority_uri,
+        tables: tables.into_iter().collect(),
+    };
+    *local_sqlite_route()
+        .write()
+        .expect("local sqlite route lock poisoned") = Some(route);
+}
+
+pub fn clear_local_sqlite_priority_route() {
+    *local_sqlite_route()
+        .write()
+        .expect("local sqlite route lock poisoned") = None;
+}
+
+fn first_table_name(sql: &str) -> Option<&str> {
+    let lower = sql.to_ascii_lowercase();
+    let from_pos = lower.find(" from ")?;
+    let after_from = &sql[from_pos + 6..];
+    let end = after_from
+        .find(|c: char| c.is_ascii_whitespace() || c == ';')
+        .unwrap_or(after_from.len());
+    let table = after_from[..end].trim();
+    if table.is_empty() { None } else { Some(table) }
+}
+
+fn local_sqlite_for_table(sql: &str) -> Option<ThreadClonedMDB> {
+    let table = first_table_name(sql)?;
+    let guard = local_sqlite_route()
+        .read()
+        .expect("local sqlite route lock poisoned");
+    let route = guard.as_ref()?;
+    if route.tables.contains(table) {
+        Some(ThreadClonedMDB::from_authority(route.authority_uri.as_str()))
+    } else {
+        None
+    }
+}
 
 fn norm_query_field(field: &DataField) -> DataField {
     DataField::new(
@@ -132,6 +186,21 @@ impl SqlQuery {
         if all_params_null {
             debug_kdb!("[sql] skip query because all params are null");
             return Vec::new();
+        }
+
+        if let Some(local_sqlite) = local_sqlite_for_table(&sql) {
+            let row = if params.is_empty() {
+                local_sqlite.query_row_with_scope(&sql)
+            } else {
+                local_sqlite.query_named_fields_with_scope(&sql, &params)
+            };
+            return match row {
+                Ok(row) => row,
+                Err(err) => {
+                    warn_kdb!("[kdb] local sqlite priority query error: {}", err);
+                    Vec::new()
+                }
+            };
         }
 
         match params.len() {
@@ -289,6 +358,21 @@ impl AsyncFieldExtractor for SqlQuery {
         if all_params_null {
             debug_kdb!("[sql] skip async query because all params are null");
             return Vec::new();
+        }
+
+        if let Some(local_sqlite) = local_sqlite_for_table(&sql) {
+            let row = if params.is_empty() {
+                local_sqlite.query_row_with_scope(&sql)
+            } else {
+                local_sqlite.query_named_fields_with_scope(&sql, &params)
+            };
+            return match row {
+                Ok(row) => row,
+                Err(err) => {
+                    warn_kdb!("[kdb] local sqlite priority async query error: {}", err);
+                    Vec::new()
+                }
+            };
         }
 
         match params.len() {

--- a/crates/wp-oml/src/core/evaluator/query/sql.rs
+++ b/crates/wp-oml/src/core/evaluator/query/sql.rs
@@ -1,9 +1,9 @@
 use crate::core::prelude::*;
 use crate::language::EvaluationTarget;
-use crate::language::SqlQuery;
+use crate::language::{SqlKnowledgeRoute, SqlQuery};
 use async_trait::async_trait;
 use std::collections::HashSet;
-use std::sync::{OnceLock, RwLock};
+use std::sync::{Arc, OnceLock};
 use wp_know::mem::thread_clone::ThreadClonedMDB;
 use wp_knowledge::facade as kdb;
 use wp_model_core::model::FieldStorage;
@@ -15,57 +15,189 @@ use crate::core::AsyncFieldExtractor;
 // would only duplicate the same partitioning work on the local-cache hot path.
 const INLINE_SQL_LOCAL_CACHE_SCOPE: u64 = 0;
 
-#[derive(Clone, Debug)]
-struct LocalSqliteRoute {
+#[derive(Clone)]
+struct TableRouteConfig {
+    sqlite: ThreadClonedMDB,
+    sqlite_tables: HashSet<String>,
+    provider_tables: HashSet<String>,
+}
+
+fn table_route_config() -> &'static OnceLock<Option<Arc<TableRouteConfig>>> {
+    static ROUTE: OnceLock<Option<Arc<TableRouteConfig>>> = OnceLock::new();
+    &ROUTE
+}
+
+pub fn set_sql_table_route(
     authority_uri: String,
-    tables: HashSet<String>,
-}
-
-fn local_sqlite_route() -> &'static RwLock<Option<LocalSqliteRoute>> {
-    static ROUTE: OnceLock<RwLock<Option<LocalSqliteRoute>>> = OnceLock::new();
-    ROUTE.get_or_init(|| RwLock::new(None))
-}
-
-pub fn set_local_sqlite_priority_route(authority_uri: String, tables: Vec<String>) {
-    let route = LocalSqliteRoute {
-        authority_uri,
-        tables: tables.into_iter().collect(),
+    sqlite_tables: Vec<String>,
+    provider_tables: Vec<String>,
+) {
+    let route = TableRouteConfig {
+        sqlite: ThreadClonedMDB::from_authority(authority_uri.as_str()),
+        sqlite_tables: sqlite_tables.into_iter().collect(),
+        provider_tables: provider_tables.into_iter().collect(),
     };
-    *local_sqlite_route()
-        .write()
-        .expect("local sqlite route lock poisoned") = Some(route);
+    let _ = table_route_config().set(Some(Arc::new(route)));
 }
 
-pub fn clear_local_sqlite_priority_route() {
-    *local_sqlite_route()
-        .write()
-        .expect("local sqlite route lock poisoned") = None;
+pub fn clear_sql_table_route() {
+    // OnceLock 不支持在运行时重置；当前路由在进程启动期初始化一次即可。
+}
+
+fn is_sql_ident_byte(byte: u8) -> bool {
+    byte == b'_' || byte.is_ascii_alphanumeric()
+}
+
+fn find_keyword(sql: &str, keyword: &[u8]) -> Option<usize> {
+    let bytes = sql.as_bytes();
+    let mut idx = 0usize;
+
+    while idx < bytes.len() {
+        match bytes[idx] {
+            b'\'' | b'"' => {
+                let quote = bytes[idx];
+                idx += 1;
+                while idx < bytes.len() {
+                    if bytes[idx] == quote {
+                        idx += 1;
+                        if idx < bytes.len() && bytes[idx] == quote {
+                            idx += 1;
+                            continue;
+                        }
+                        break;
+                    }
+                    idx += 1;
+                }
+            }
+            b'`' => {
+                idx += 1;
+                while idx < bytes.len() && bytes[idx] != b'`' {
+                    idx += 1;
+                }
+                idx += usize::from(idx < bytes.len());
+            }
+            b'[' => {
+                idx += 1;
+                while idx < bytes.len() && bytes[idx] != b']' {
+                    idx += 1;
+                }
+                idx += usize::from(idx < bytes.len());
+            }
+            _ => {
+                let end = idx + keyword.len();
+                if end <= bytes.len()
+                    && bytes[idx..end].eq_ignore_ascii_case(keyword)
+                    && idx
+                        .checked_sub(1)
+                        .is_none_or(|prev| !is_sql_ident_byte(bytes[prev]))
+                    && bytes.get(end).is_none_or(|next| !is_sql_ident_byte(*next))
+                {
+                    return Some(idx);
+                }
+                idx += 1;
+            }
+        }
+    }
+
+    None
+}
+
+fn matching_paren(sql: &str, open_pos: usize) -> Option<usize> {
+    let bytes = sql.as_bytes();
+    let mut depth = 0usize;
+    let mut idx = open_pos;
+
+    while idx < bytes.len() {
+        match bytes[idx] {
+            b'\'' | b'"' => {
+                let quote = bytes[idx];
+                idx += 1;
+                while idx < bytes.len() {
+                    if bytes[idx] == quote {
+                        idx += 1;
+                        if idx < bytes.len() && bytes[idx] == quote {
+                            idx += 1;
+                            continue;
+                        }
+                        break;
+                    }
+                    idx += 1;
+                }
+            }
+            b'`' => {
+                idx += 1;
+                while idx < bytes.len() && bytes[idx] != b'`' {
+                    idx += 1;
+                }
+                idx += usize::from(idx < bytes.len());
+            }
+            b'[' => {
+                idx += 1;
+                while idx < bytes.len() && bytes[idx] != b']' {
+                    idx += 1;
+                }
+                idx += usize::from(idx < bytes.len());
+            }
+            b'(' => {
+                depth += 1;
+                idx += 1;
+            }
+            b')' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(idx);
+                }
+                idx += 1;
+            }
+            _ => idx += 1,
+        }
+    }
+
+    None
 }
 
 fn first_table_name(sql: &str) -> Option<&str> {
-    let lower = sql.to_ascii_lowercase();
-    let from_pos = lower.find(" from ")?;
-    let after_from = &sql[from_pos + 6..];
-    let end = after_from
-        .find(|c: char| c.is_ascii_whitespace() || c == ';')
-        .unwrap_or(after_from.len());
-    let table = after_from[..end].trim();
+    let from_pos = find_keyword(sql, b"from")?;
+    let mut table_start = from_pos + b"from".len();
+    let bytes = sql.as_bytes();
+    while table_start < bytes.len() && bytes[table_start].is_ascii_whitespace() {
+        table_start += 1;
+    }
+
+    if bytes.get(table_start) == Some(&b'(') {
+        let close_pos = matching_paren(sql, table_start)?;
+        return first_table_name(&sql[table_start + 1..close_pos]);
+    }
+
+    let table_end = sql[table_start..]
+        .find(|c: char| c.is_ascii_whitespace() || matches!(c, ';' | ',' | ')'))
+        .map_or(sql.len(), |end| table_start + end);
+    let table = sql[table_start..table_end].trim();
     if table.is_empty() { None } else { Some(table) }
 }
 
-fn local_sqlite_for_table(sql: &str) -> Option<ThreadClonedMDB> {
-    let table = first_table_name(sql)?;
-    let guard = local_sqlite_route()
-        .read()
-        .expect("local sqlite route lock poisoned");
-    let route = guard.as_ref()?;
-    if route.tables.contains(table) {
-        Some(ThreadClonedMDB::from_authority(
-            route.authority_uri.as_str(),
-        ))
-    } else {
-        None
+pub fn resolve_sql_route(sql: &str) -> SqlKnowledgeRoute {
+    let Some(table) = first_table_name(sql) else {
+        return SqlKnowledgeRoute::Unknown;
+    };
+    let Some(route) = table_route_config().get().and_then(|route| route.as_ref()) else {
+        return SqlKnowledgeRoute::Provider;
+    };
+    if route.sqlite_tables.contains(table) {
+        return SqlKnowledgeRoute::Sqlite;
     }
+    if route.provider_tables.contains(table) {
+        return SqlKnowledgeRoute::Provider;
+    }
+    SqlKnowledgeRoute::Provider
+}
+
+fn local_sqlite_for_route(route: SqlKnowledgeRoute) -> Option<ThreadClonedMDB> {
+    if route != SqlKnowledgeRoute::Sqlite {
+        return None;
+    }
+    let route = table_route_config().get()?.as_ref()?;
+    Some(route.sqlite.clone())
 }
 
 fn norm_query_field(field: &DataField) -> DataField {
@@ -190,7 +322,7 @@ impl SqlQuery {
             return Vec::new();
         }
 
-        if let Some(local_sqlite) = local_sqlite_for_table(&sql) {
+        if let Some(local_sqlite) = local_sqlite_for_route(*self.route()) {
             let row = if params.is_empty() {
                 local_sqlite.query_row_with_scope(&sql)
             } else {
@@ -199,7 +331,7 @@ impl SqlQuery {
             return match row {
                 Ok(row) => row,
                 Err(err) => {
-                    warn_kdb!("[kdb] local sqlite priority query error: {}", err);
+                    warn_kdb!("[kdb] local sqlite routed query error: {}", err);
                     Vec::new()
                 }
             };
@@ -362,7 +494,7 @@ impl AsyncFieldExtractor for SqlQuery {
             return Vec::new();
         }
 
-        if let Some(local_sqlite) = local_sqlite_for_table(&sql) {
+        if let Some(local_sqlite) = local_sqlite_for_route(*self.route()) {
             let row = if params.is_empty() {
                 local_sqlite.query_row_with_scope(&sql)
             } else {
@@ -371,7 +503,7 @@ impl AsyncFieldExtractor for SqlQuery {
             return match row {
                 Ok(row) => row,
                 Err(err) => {
-                    warn_kdb!("[kdb] local sqlite priority async query error: {}", err);
+                    warn_kdb!("[kdb] local sqlite routed async query error: {}", err);
                     Vec::new()
                 }
             };
@@ -557,6 +689,60 @@ mod tests {
                 .map(|(name, field)| (name.to_string(), CondAccessor::Val(field.value)))
                 .collect(),
         )
+    }
+
+    #[test]
+    fn test_resolve_sql_route_prefers_sqlite_for_sqlite_tables() {
+        set_sql_table_route(
+            "file:/tmp/test-authority.sqlite?mode=ro&uri=true".to_string(),
+            vec!["local_asset_data".to_string()],
+            vec!["asset_data".to_string()],
+        );
+
+        assert!(matches!(
+            resolve_sql_route("SELECT asset FROM local_asset_data WHERE ip = :ip"),
+            SqlKnowledgeRoute::Sqlite
+        ));
+        assert!(matches!(
+            resolve_sql_route("SELECT asset FROM asset_data WHERE ip = :ip"),
+            SqlKnowledgeRoute::Provider
+        ));
+    }
+
+    #[test]
+    fn test_resolve_sql_route_reads_table_from_subquery() {
+        set_sql_table_route(
+            "file:/tmp/test-authority.sqlite?mode=ro&uri=true".to_string(),
+            vec!["local_asset_data".to_string()],
+            vec!["asset_data".to_string()],
+        );
+
+        assert!(matches!(
+            resolve_sql_route(
+                "SELECT asset FROM (SELECT asset FROM local_asset_data WHERE ip = :ip) AS local_hits"
+            ),
+            SqlKnowledgeRoute::Sqlite
+        ));
+        assert!(matches!(
+            resolve_sql_route(
+                "SELECT asset FROM (SELECT asset FROM (SELECT asset FROM asset_data) nested) hits"
+            ),
+            SqlKnowledgeRoute::Provider
+        ));
+    }
+
+    #[test]
+    fn test_resolve_sql_route_ignores_from_inside_string_literal() {
+        set_sql_table_route(
+            "file:/tmp/test-authority.sqlite?mode=ro&uri=true".to_string(),
+            vec!["local_asset_data".to_string()],
+            vec!["asset_data".to_string()],
+        );
+
+        assert!(matches!(
+            resolve_sql_route("SELECT ' from asset_data ' AS marker FROM local_asset_data"),
+            SqlKnowledgeRoute::Sqlite
+        ));
     }
 
     #[test]

--- a/crates/wp-oml/src/core/evaluator/query/sql.rs
+++ b/crates/wp-oml/src/core/evaluator/query/sql.rs
@@ -4,8 +4,8 @@ use crate::language::SqlQuery;
 use async_trait::async_trait;
 use std::collections::HashSet;
 use std::sync::{OnceLock, RwLock};
-use wp_knowledge::facade as kdb;
 use wp_know::mem::thread_clone::ThreadClonedMDB;
+use wp_knowledge::facade as kdb;
 use wp_model_core::model::FieldStorage;
 use wp_model_core::model::{DataType, Value};
 
@@ -60,7 +60,9 @@ fn local_sqlite_for_table(sql: &str) -> Option<ThreadClonedMDB> {
         .expect("local sqlite route lock poisoned");
     let route = guard.as_ref()?;
     if route.tables.contains(table) {
-        Some(ThreadClonedMDB::from_authority(route.authority_uri.as_str()))
+        Some(ThreadClonedMDB::from_authority(
+            route.authority_uri.as_str(),
+        ))
     } else {
         None
     }

--- a/crates/wp-oml/src/language/mod.rs
+++ b/crates/wp-oml/src/language/mod.rs
@@ -33,7 +33,7 @@ pub use syntax::{
         CalcExpr, CalcFun, CalcNumber, CalcOp, CalcOperation, FmtOperation, LookupDict,
         LookupOperation, MapOperation, MatchAble, MatchCase, MatchCond, MatchCondition, MatchFun,
         MatchOperation, MatchSource, PiPeOperation, RecordOperation, RecordOperationBuilder,
-        SqlQuery,
+        SqlKnowledgeRoute, SqlQuery,
     },
 };
 pub use types::model::DataModel;

--- a/crates/wp-oml/src/language/syntax/operations/sql.rs
+++ b/crates/wp-oml/src/language/syntax/operations/sql.rs
@@ -3,21 +3,38 @@ use std::collections::HashMap;
 use wp_data_fmt::SqlInsert;
 // 已移除对具体 DB 的依赖；通过门面在运行期解析
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SqlKnowledgeRoute {
+    Provider,
+    Sqlite,
+    Unknown,
+}
+
 #[derive(Builder, Debug, Clone, Getters)]
 pub struct SqlQuery {
     oml_sql: String,
     sql_md5: String,
     vars: HashMap<String, CondAccessor>,
+    route: SqlKnowledgeRoute,
 }
 
 impl SqlQuery {
     pub fn new(sql: String, vars: HashMap<String, CondAccessor>) -> Self {
+        Self::new_with_route(sql, vars, SqlKnowledgeRoute::Provider)
+    }
+
+    pub fn new_with_route(
+        sql: String,
+        vars: HashMap<String, CondAccessor>,
+        route: SqlKnowledgeRoute,
+    ) -> Self {
         let sql_md5 = format!("{:x}", md5::compute(sql.as_bytes()));
 
         Self {
             oml_sql: sql,
             vars,
             sql_md5,
+            route,
         }
     }
 }

--- a/crates/wp-oml/src/parser/sql_prm.rs
+++ b/crates/wp-oml/src/parser/sql_prm.rs
@@ -13,6 +13,7 @@ use wp_primitives::Parser;
 use wp_primitives::WResult;
 use wp_primitives::symbol::ctx_desc;
 
+use crate::core::evaluator::query::sql::resolve_sql_route;
 use crate::language::{
     ArgsTakeAble, CondAccessor, DirectAccessor, FieldTake, PreciseEvaluator, RecordOperation,
     SqlQuery,
@@ -184,18 +185,143 @@ fn is_supported_string_agg_inner(inner: &str) -> bool {
     is_sql_ident(expr) && is_sql_string_literal(delimiter)
 }
 
+fn find_matching_paren(input: &str, open_pos: usize) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let mut depth = 0i32;
+    let mut in_single = false;
+    let mut in_double = false;
+
+    for (idx, ch) in input.char_indices().skip_while(|(idx, _)| *idx < open_pos) {
+        match ch {
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            '(' if !in_single && !in_double => depth += 1,
+            ')' if !in_single && !in_double => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(idx);
+                }
+                if depth < 0 {
+                    return None;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let _ = bytes;
+    None
+}
+
+fn find_top_level_from(body: &str) -> Option<usize> {
+    let bytes = body.as_bytes();
+    let mut idx = 0usize;
+    let mut depth = 0i32;
+    let mut in_single = false;
+    let mut in_double = false;
+
+    while idx < bytes.len() {
+        let ch = bytes[idx] as char;
+        match ch {
+            '\'' if !in_double => {
+                in_single = !in_single;
+                idx += 1;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                idx += 1;
+            }
+            '(' if !in_single && !in_double => {
+                depth += 1;
+                idx += 1;
+            }
+            ')' if !in_single && !in_double => {
+                depth -= 1;
+                if depth < 0 {
+                    return None;
+                }
+                idx += 1;
+            }
+            _ => {
+                if !in_single
+                    && !in_double
+                    && depth == 0
+                    && idx + 4 <= bytes.len()
+                    && bytes[idx..idx + 4].eq_ignore_ascii_case(b"from")
+                    && idx
+                        .checked_sub(1)
+                        .is_some_and(|prev| bytes[prev].is_ascii_whitespace())
+                    && bytes
+                        .get(idx + 4)
+                        .is_some_and(|next| next.is_ascii_whitespace())
+                {
+                    return Some(idx);
+                }
+                idx += 1;
+            }
+        }
+    }
+
+    None
+}
+
+fn sanitize_select_stmt(stmt: &str) -> Option<String> {
+    let stmt = stmt.trim();
+    let lower = stmt.to_ascii_lowercase();
+    let select_kw = "select ";
+    if !lower.starts_with(select_kw) {
+        return None;
+    }
+    let body = &stmt[select_kw.len()..];
+    let sanitized = sanitize_sql_body(body)?;
+    Some(format!("select {}", sanitized))
+}
+
+fn sanitize_from_source(source: &str) -> Option<String> {
+    let source = source.trim();
+    if source.is_empty() {
+        return None;
+    }
+    if is_sql_ident(source) {
+        return Some(source.to_string());
+    }
+    if !source.starts_with('(') {
+        return None;
+    }
+
+    let close_pos = find_matching_paren(source, 0)?;
+    let inner = source[1..close_pos].trim();
+    let remainder = source[close_pos + 1..].trim();
+    let alias = if remainder.is_empty() {
+        None
+    } else if remainder.len() >= 3 && remainder[..3].eq_ignore_ascii_case("as ") {
+        let alias = remainder[3..].trim();
+        if !is_sql_ident(alias) {
+            return None;
+        }
+        Some(alias)
+    } else {
+        if !is_sql_ident(remainder) {
+            return None;
+        }
+        Some(remainder)
+    };
+
+    let sanitized_inner = sanitize_select_stmt(inner)?;
+    match alias {
+        Some(alias) => Some(format!("({}) {}", sanitized_inner, alias)),
+        None => Some(format!("({})", sanitized_inner)),
+    }
+}
+
 /// Sanitize SQL body to ensure safe identifiers.
 /// Only allows `<cols> from <table>` where cols are identifiers, `*`, or a single
 /// SQL function call like `group_concat(distinct asset_type)`.
 fn sanitize_sql_body(body: &str) -> Option<String> {
     let body_trim = body.trim();
-    let lower = body_trim.to_lowercase();
-    let from_pos = lower.rfind(" from ")?;
-    let (cols_part, table_part) = body_trim.split_at(from_pos);
-    let table_name = table_part[" from ".len()..].trim();
-    if table_name.is_empty() || !is_sql_ident(table_name) {
-        return None;
-    }
+    let from_pos = find_top_level_from(body_trim)?;
+    let cols_part = &body_trim[..from_pos];
+    let table_name = sanitize_from_source(body_trim[from_pos + 4..].trim())?;
     let cols = split_top_level_commas(cols_part)?;
     if cols.is_empty() {
         return None;
@@ -462,13 +588,15 @@ pub fn oml_sql(data: &mut &str) -> WResult<SqlQuery> {
     // 优先处理 ip4_between(...)=1 这类 SQL 专用条件，避免落回通用条件解析。
     if let Some((w_sql, vars)) = fast_path_ip4_between_eq_one(&sql_cond_buf) {
         let sql = format!("select {} where {}", sql_body, w_sql);
-        return Ok(SqlQuery::new(sql, vars));
+        let route = resolve_sql_route(&sql);
+        return Ok(SqlQuery::new_with_route(sql, vars, route));
     }
 
     // 优先处理 field in (...)，支持 @ref 形式的 OML 变量引用。
     if let Some((w_sql, vars)) = fast_path_in_list(&sql_cond_buf) {
         let sql = format!("select {} where {}", sql_body, w_sql);
-        return Ok(SqlQuery::new(sql, vars));
+        let route = resolve_sql_route(&sql);
+        return Ok(SqlQuery::new_with_route(sql, vars, route));
     }
 
     // Generic path
@@ -492,7 +620,8 @@ pub fn oml_sql(data: &mut &str) -> WResult<SqlQuery> {
     };
 
     let sql = format!("select {} where {}", safe_body, w_sql);
-    Ok(SqlQuery::new(sql, vars))
+    let route = resolve_sql_route(&sql);
+    Ok(SqlQuery::new_with_route(sql, vars, route))
 }
 
 pub fn oml_aga_sql(data: &mut &str) -> WResult<PreciseEvaluator> {
@@ -556,6 +685,12 @@ mod tests {
         );
         assert!(parsed.vars().contains_key("sip"));
         assert!(parsed.vars().contains_key("dip"));
+        assert!(matches!(
+            parsed.route(),
+            crate::language::SqlKnowledgeRoute::Provider
+                | crate::language::SqlKnowledgeRoute::Sqlite
+                | crate::language::SqlKnowledgeRoute::Unknown
+        ));
         Ok(())
     }
 
@@ -678,6 +813,41 @@ mod tests {
                 .collect::<Vec<_>>()
                 .join(" "),
             "select string_agg(distinct asset_type, ',') from v_asset_ip_details where ip = :ip"
+        );
+        assert!(parsed.vars().contains_key("ip"));
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_oml_sql_subquery_body_ok() -> ModalResult<()> {
+        super::set_sql_strict_for_test(Some(true));
+        let mut code = r#" select asset from (select * from asset_data) where ip = @src_ip ;"#;
+        let parsed = oml_sql.parse_next(&mut code)?;
+        assert_eq!(
+            parsed
+                .oml_sql()
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" "),
+            "select asset from (select * from asset_data) where ip = :ip"
+        );
+        assert!(parsed.vars().contains_key("ip"));
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_oml_sql_subquery_body_with_alias_ok() -> ModalResult<()> {
+        super::set_sql_strict_for_test(Some(true));
+        let mut code =
+            r#" select asset from (select * from asset_data) as hits where ip = @src_ip ;"#;
+        let parsed = oml_sql.parse_next(&mut code)?;
+        assert_eq!(
+            parsed
+                .oml_sql()
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" "),
+            "select asset from (select * from asset_data) hits where ip = :ip"
         );
         assert!(parsed.vars().contains_key("ip"));
         Ok(())

--- a/src/facade/engine.rs
+++ b/src/facade/engine.rs
@@ -2,9 +2,8 @@
 
 use crate::compat::LegacyOwe;
 use futures_lite::StreamExt;
-use oml::core::evaluator::query::sql::set_local_sqlite_priority_route;
+use oml::core::evaluator::query::sql::set_sql_table_route;
 use orion_variate::EnvDict;
-use serde::Deserialize;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -29,6 +28,9 @@ use crate::facade::args::resolve_run_work_root;
 use crate::facade::runtime_ctrl::{
     CommandType, RuntimeCommandReq, RuntimeCommandResp, RuntimeCommandResult, RuntimeControlHandle,
     default_runtime_command_bus,
+};
+use crate::knowledge::{
+    load_local_table_names, load_provider_table_names, uses_external_provider_only,
 };
 use crate::orchestrator::config::loader::WarpConf;
 use crate::orchestrator::config::models::{load_warp_engine_confs, stat_reqs_from};
@@ -66,59 +68,6 @@ fn semantic_dict_config_path(main_conf: &EngineConfig, work_root: &Path) -> Path
 
 fn knowdb_config_path(main_conf: &EngineConfig) -> PathBuf {
     PathBuf::from(main_conf.knowledge_root()).join("knowdb.toml")
-}
-
-#[derive(Deserialize)]
-struct KnowdbProviderProbe {
-    #[serde(default)]
-    kind: Option<String>,
-}
-
-#[derive(Deserialize)]
-struct KnowdbProbe {
-    #[serde(default)]
-    provider: Option<KnowdbProviderProbe>,
-    #[serde(default)]
-    tables: Vec<KnowdbTableProbe>,
-}
-
-#[derive(Deserialize)]
-struct KnowdbTableProbe {
-    name: String,
-    #[serde(default = "default_true")]
-    enabled: bool,
-}
-
-const fn default_true() -> bool {
-    true
-}
-
-fn should_rebuild_local_authority(knowdb_path: &Path) -> bool {
-    let Ok(body) = std::fs::read_to_string(knowdb_path) else {
-        return true;
-    };
-    let Ok(probe) = toml::from_str::<KnowdbProbe>(&body) else {
-        return true;
-    };
-    let Some(provider) = probe.provider else {
-        return true;
-    };
-    !matches!(provider.kind.as_deref(), Some("postgres") | Some("mysql"))
-}
-
-fn load_local_table_names(knowdb_path: &Path) -> Vec<String> {
-    let Ok(body) = std::fs::read_to_string(knowdb_path) else {
-        return Vec::new();
-    };
-    let Ok(probe) = toml::from_str::<KnowdbProbe>(&body) else {
-        return Vec::new();
-    };
-    probe
-        .tables
-        .into_iter()
-        .filter(|table| table.enabled)
-        .map(|table| table.name)
-        .collect()
 }
 
 /// wparse 应用入口：对外隐藏内部装配细节
@@ -477,8 +426,9 @@ async fn load_engine_res(
     let mut knowdb_handler = None;
     if knowdb_path.exists() {
         let local_tables = load_local_table_names(&knowdb_path);
+        let provider_tables = load_provider_table_names(&knowdb_path);
         let auth_file = PathBuf::from(conf_manager.runtime_path("authority.sqlite"));
-        if should_rebuild_local_authority(&knowdb_path) || !local_tables.is_empty() {
+        if !uses_external_provider_only(&knowdb_path) || !local_tables.is_empty() {
             let _ = std::fs::remove_file(&auth_file);
         }
         let authority_uri = format!("file:{}?mode=rwc&uri=true", auth_file.display());
@@ -489,7 +439,11 @@ async fn load_engine_res(
                 &authority_uri,
                 env_dict,
             );
-            set_local_sqlite_priority_route(readonly_authority_uri(&authority_uri), local_tables);
+            set_sql_table_route(
+                readonly_authority_uri(&authority_uri),
+                local_tables,
+                provider_tables,
+            );
         }
         match init_thread_cloned_from_knowdb(
             Path::new(conf_manager.work_root_path().as_str()),
@@ -606,9 +560,10 @@ async fn load_processing_res(
     let mut knowdb_handler = None;
     if knowdb_path.exists() {
         let local_tables = load_local_table_names(&knowdb_path);
+        let provider_tables = load_provider_table_names(&knowdb_path);
         let authority_uri = processing_authority_uri(conf_manager, options.persist_runtime_state);
         if options.persist_runtime_state
-            && (should_rebuild_local_authority(&knowdb_path) || !local_tables.is_empty())
+            && (!uses_external_provider_only(&knowdb_path) || !local_tables.is_empty())
             && let Some(auth_file) = authority_path_from_uri(&authority_uri)
             && Path::new(auth_file).exists()
         {
@@ -621,7 +576,11 @@ async fn load_processing_res(
                 &authority_uri,
                 env_dict,
             );
-            set_local_sqlite_priority_route(readonly_authority_uri(&authority_uri), local_tables);
+            set_sql_table_route(
+                readonly_authority_uri(&authority_uri),
+                local_tables,
+                provider_tables,
+            );
         }
         match init_thread_cloned_from_knowdb(
             Path::new(conf_manager.work_root_path().as_str()),

--- a/src/facade/engine.rs
+++ b/src/facade/engine.rs
@@ -1,8 +1,8 @@
 //! wparse 引擎的 Facade 封装：装配/启动/重载/优雅退出 与 PID 管理。
 
 use crate::compat::LegacyOwe;
-use oml::core::evaluator::query::sql::set_local_sqlite_priority_route;
 use futures_lite::StreamExt;
+use oml::core::evaluator::query::sql::set_local_sqlite_priority_route;
 use orion_variate::EnvDict;
 use serde::Deserialize;
 use std::path::Path;

--- a/src/facade/engine.rs
+++ b/src/facade/engine.rs
@@ -1,14 +1,17 @@
 //! wparse 引擎的 Facade 封装：装配/启动/重载/优雅退出 与 PID 管理。
 
 use crate::compat::LegacyOwe;
+use oml::core::evaluator::query::sql::set_local_sqlite_priority_route;
 use futures_lite::StreamExt;
 use orion_variate::EnvDict;
+use serde::Deserialize;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::Receiver;
 use tokio::time::timeout;
 use wp_knowledge::facade::init_thread_cloned_from_knowdb;
+use wp_knowledge::loader::build_authority_from_knowdb;
 
 use orion_error::{
     OperationContext,
@@ -63,6 +66,59 @@ fn semantic_dict_config_path(main_conf: &EngineConfig, work_root: &Path) -> Path
 
 fn knowdb_config_path(main_conf: &EngineConfig) -> PathBuf {
     PathBuf::from(main_conf.knowledge_root()).join("knowdb.toml")
+}
+
+#[derive(Deserialize)]
+struct KnowdbProviderProbe {
+    #[serde(default)]
+    kind: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct KnowdbProbe {
+    #[serde(default)]
+    provider: Option<KnowdbProviderProbe>,
+    #[serde(default)]
+    tables: Vec<KnowdbTableProbe>,
+}
+
+#[derive(Deserialize)]
+struct KnowdbTableProbe {
+    name: String,
+    #[serde(default = "default_true")]
+    enabled: bool,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+fn should_rebuild_local_authority(knowdb_path: &Path) -> bool {
+    let Ok(body) = std::fs::read_to_string(knowdb_path) else {
+        return true;
+    };
+    let Ok(probe) = toml::from_str::<KnowdbProbe>(&body) else {
+        return true;
+    };
+    let Some(provider) = probe.provider else {
+        return true;
+    };
+    !matches!(provider.kind.as_deref(), Some("postgres") | Some("mysql"))
+}
+
+fn load_local_table_names(knowdb_path: &Path) -> Vec<String> {
+    let Ok(body) = std::fs::read_to_string(knowdb_path) else {
+        return Vec::new();
+    };
+    let Ok(probe) = toml::from_str::<KnowdbProbe>(&body) else {
+        return Vec::new();
+    };
+    probe
+        .tables
+        .into_iter()
+        .filter(|table| table.enabled)
+        .map(|table| table.name)
+        .collect()
 }
 
 /// wparse 应用入口：对外隐藏内部装配细节
@@ -420,9 +476,21 @@ async fn load_engine_res(
     let knowdb_path = knowdb_config_path(main_conf);
     let mut knowdb_handler = None;
     if knowdb_path.exists() {
+        let local_tables = load_local_table_names(&knowdb_path);
         let auth_file = PathBuf::from(conf_manager.runtime_path("authority.sqlite"));
-        let _ = std::fs::remove_file(&auth_file);
+        if should_rebuild_local_authority(&knowdb_path) || !local_tables.is_empty() {
+            let _ = std::fs::remove_file(&auth_file);
+        }
         let authority_uri = format!("file:{}?mode=rwc&uri=true", auth_file.display());
+        if !local_tables.is_empty() {
+            let _ = build_authority_from_knowdb(
+                Path::new(conf_manager.work_root_path().as_str()),
+                &knowdb_path,
+                &authority_uri,
+                env_dict,
+            );
+            set_local_sqlite_priority_route(readonly_authority_uri(&authority_uri), local_tables);
+        }
         match init_thread_cloned_from_knowdb(
             Path::new(conf_manager.work_root_path().as_str()),
             &knowdb_path,
@@ -537,12 +605,23 @@ async fn load_processing_res(
     let knowdb_path = knowdb_config_path(main_conf);
     let mut knowdb_handler = None;
     if knowdb_path.exists() {
+        let local_tables = load_local_table_names(&knowdb_path);
         let authority_uri = processing_authority_uri(conf_manager, options.persist_runtime_state);
         if options.persist_runtime_state
+            && (should_rebuild_local_authority(&knowdb_path) || !local_tables.is_empty())
             && let Some(auth_file) = authority_path_from_uri(&authority_uri)
             && Path::new(auth_file).exists()
         {
             let _ = std::fs::remove_file(auth_file);
+        }
+        if !local_tables.is_empty() {
+            let _ = build_authority_from_knowdb(
+                Path::new(conf_manager.work_root_path().as_str()),
+                &knowdb_path,
+                &authority_uri,
+                env_dict,
+            );
+            set_local_sqlite_priority_route(readonly_authority_uri(&authority_uri), local_tables);
         }
         match init_thread_cloned_from_knowdb(
             Path::new(conf_manager.work_root_path().as_str()),
@@ -664,6 +743,14 @@ fn authority_path_from_uri(uri: &str) -> Option<&str> {
         return None;
     }
     Some(path)
+}
+
+fn readonly_authority_uri(authority_uri: &str) -> String {
+    if let Some(rest) = authority_uri.strip_prefix("file:") {
+        let path_part = rest.split('?').next().unwrap_or(rest);
+        return format!("file:{}?mode=ro&uri=true", path_part);
+    }
+    authority_uri.to_string()
 }
 
 #[cfg(test)]

--- a/src/facade/rescue.rs
+++ b/src/facade/rescue.rs
@@ -5,12 +5,15 @@ use std::sync::Arc;
 
 use orion_error::conversion::ConvErr;
 use orion_variate::EnvDict;
+use serde::Deserialize;
 use wp_conf::RunArgs;
 use wp_error::run_error::RunResult;
 use wp_log::conf::log_init;
+use wp_knowledge::loader::build_authority_from_knowdb;
 use wp_stat::{StatRequires, StatStage};
 
 use crate::facade::args::{ParseArgs, resolve_run_work_root};
+use oml::core::evaluator::query::sql::set_local_sqlite_priority_route;
 use crate::orchestrator::config::loader::WarpConf;
 use crate::orchestrator::config::models::{load_warp_engine_confs, stat_reqs_from};
 use crate::orchestrator::engine::recovery::recover_main;
@@ -19,6 +22,59 @@ use crate::runtime::sink::act_sink::SinkService;
 use crate::runtime::sink::infrastructure::InfraSinkService;
 use crate::utils::process::PidRec;
 use wp_conf::engine::EngineConfig;
+
+#[derive(Deserialize)]
+struct KnowdbProviderProbe {
+    #[serde(default)]
+    kind: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct KnowdbProbe {
+    #[serde(default)]
+    provider: Option<KnowdbProviderProbe>,
+    #[serde(default)]
+    tables: Vec<KnowdbTableProbe>,
+}
+
+#[derive(Deserialize)]
+struct KnowdbTableProbe {
+    name: String,
+    #[serde(default = "default_true")]
+    enabled: bool,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+fn should_rebuild_local_authority(knowdb_path: &Path) -> bool {
+    let Ok(body) = std::fs::read_to_string(knowdb_path) else {
+        return true;
+    };
+    let Ok(probe) = toml::from_str::<KnowdbProbe>(&body) else {
+        return true;
+    };
+    let Some(provider) = probe.provider else {
+        return true;
+    };
+    !matches!(provider.kind.as_deref(), Some("postgres") | Some("mysql"))
+}
+
+fn load_local_table_names(knowdb_path: &Path) -> Vec<String> {
+    let Ok(body) = std::fs::read_to_string(knowdb_path) else {
+        return Vec::new();
+    };
+    let Ok(probe) = toml::from_str::<KnowdbProbe>(&body) else {
+        return Vec::new();
+    };
+    probe
+        .tables
+        .into_iter()
+        .filter(|table| table.enabled)
+        .map(|table| table.name)
+        .collect()
+}
 
 /// wprescue 应用入口（batch-only）
 pub struct WpRescueApp {
@@ -56,10 +112,22 @@ impl WpRescueApp {
         let knowdb_path =
             std::path::PathBuf::from(self.main_conf.knowledge_root()).join("knowdb.toml");
         if knowdb_path.exists() {
+            let local_tables = load_local_table_names(&knowdb_path);
             let auth_file =
                 std::path::PathBuf::from(self.conf_manager.runtime_path("authority.sqlite"));
-            let _ = std::fs::remove_file(&auth_file);
+            if should_rebuild_local_authority(&knowdb_path) || !local_tables.is_empty() {
+                let _ = std::fs::remove_file(&auth_file);
+            }
             let authority_uri = format!("file:{}?mode=rwc&uri=true", auth_file.display());
+            if !local_tables.is_empty() {
+                let _ = build_authority_from_knowdb(
+                    Path::new(self.conf_manager.work_root_path().as_str()),
+                    &knowdb_path,
+                    &authority_uri,
+                    &self.val_dict,
+                );
+                set_local_sqlite_priority_route(authority_uri.clone(), local_tables);
+            }
             match wp_knowledge::facade::init_thread_cloned_from_knowdb(
                 Path::new(self.conf_manager.work_root_path().as_str()),
                 &knowdb_path,

--- a/src/facade/rescue.rs
+++ b/src/facade/rescue.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use orion_error::conversion::ConvErr;
 use orion_variate::EnvDict;
-use serde::Deserialize;
 use wp_conf::RunArgs;
 use wp_error::run_error::RunResult;
 use wp_knowledge::loader::build_authority_from_knowdb;
@@ -13,6 +12,9 @@ use wp_log::conf::log_init;
 use wp_stat::{StatRequires, StatStage};
 
 use crate::facade::args::{ParseArgs, resolve_run_work_root};
+use crate::knowledge::{
+    load_local_table_names, load_provider_table_names, uses_external_provider_only,
+};
 use crate::orchestrator::config::loader::WarpConf;
 use crate::orchestrator::config::models::{load_warp_engine_confs, stat_reqs_from};
 use crate::orchestrator::engine::recovery::recover_main;
@@ -20,60 +22,15 @@ use crate::resources::core::manager::ResManager;
 use crate::runtime::sink::act_sink::SinkService;
 use crate::runtime::sink::infrastructure::InfraSinkService;
 use crate::utils::process::PidRec;
-use oml::core::evaluator::query::sql::set_local_sqlite_priority_route;
+use oml::core::evaluator::query::sql::set_sql_table_route;
 use wp_conf::engine::EngineConfig;
 
-#[derive(Deserialize)]
-struct KnowdbProviderProbe {
-    #[serde(default)]
-    kind: Option<String>,
-}
-
-#[derive(Deserialize)]
-struct KnowdbProbe {
-    #[serde(default)]
-    provider: Option<KnowdbProviderProbe>,
-    #[serde(default)]
-    tables: Vec<KnowdbTableProbe>,
-}
-
-#[derive(Deserialize)]
-struct KnowdbTableProbe {
-    name: String,
-    #[serde(default = "default_true")]
-    enabled: bool,
-}
-
-const fn default_true() -> bool {
-    true
-}
-
-fn should_rebuild_local_authority(knowdb_path: &Path) -> bool {
-    let Ok(body) = std::fs::read_to_string(knowdb_path) else {
-        return true;
-    };
-    let Ok(probe) = toml::from_str::<KnowdbProbe>(&body) else {
-        return true;
-    };
-    let Some(provider) = probe.provider else {
-        return true;
-    };
-    !matches!(provider.kind.as_deref(), Some("postgres") | Some("mysql"))
-}
-
-fn load_local_table_names(knowdb_path: &Path) -> Vec<String> {
-    let Ok(body) = std::fs::read_to_string(knowdb_path) else {
-        return Vec::new();
-    };
-    let Ok(probe) = toml::from_str::<KnowdbProbe>(&body) else {
-        return Vec::new();
-    };
-    probe
-        .tables
-        .into_iter()
-        .filter(|table| table.enabled)
-        .map(|table| table.name)
-        .collect()
+fn readonly_authority_uri(authority_uri: &str) -> String {
+    if let Some(rest) = authority_uri.strip_prefix("file:") {
+        let path_part = rest.split('?').next().unwrap_or(rest);
+        return format!("file:{}?mode=ro&uri=true", path_part);
+    }
+    authority_uri.to_string()
 }
 
 /// wprescue 应用入口（batch-only）
@@ -113,9 +70,10 @@ impl WpRescueApp {
             std::path::PathBuf::from(self.main_conf.knowledge_root()).join("knowdb.toml");
         if knowdb_path.exists() {
             let local_tables = load_local_table_names(&knowdb_path);
+            let provider_tables = load_provider_table_names(&knowdb_path);
             let auth_file =
                 std::path::PathBuf::from(self.conf_manager.runtime_path("authority.sqlite"));
-            if should_rebuild_local_authority(&knowdb_path) || !local_tables.is_empty() {
+            if !uses_external_provider_only(&knowdb_path) || !local_tables.is_empty() {
                 let _ = std::fs::remove_file(&auth_file);
             }
             let authority_uri = format!("file:{}?mode=rwc&uri=true", auth_file.display());
@@ -126,7 +84,11 @@ impl WpRescueApp {
                     &authority_uri,
                     &self.val_dict,
                 );
-                set_local_sqlite_priority_route(authority_uri.clone(), local_tables);
+                set_sql_table_route(
+                    readonly_authority_uri(&authority_uri),
+                    local_tables,
+                    provider_tables,
+                );
             }
             match wp_knowledge::facade::init_thread_cloned_from_knowdb(
                 Path::new(self.conf_manager.work_root_path().as_str()),

--- a/src/facade/rescue.rs
+++ b/src/facade/rescue.rs
@@ -8,12 +8,11 @@ use orion_variate::EnvDict;
 use serde::Deserialize;
 use wp_conf::RunArgs;
 use wp_error::run_error::RunResult;
-use wp_log::conf::log_init;
 use wp_knowledge::loader::build_authority_from_knowdb;
+use wp_log::conf::log_init;
 use wp_stat::{StatRequires, StatStage};
 
 use crate::facade::args::{ParseArgs, resolve_run_work_root};
-use oml::core::evaluator::query::sql::set_local_sqlite_priority_route;
 use crate::orchestrator::config::loader::WarpConf;
 use crate::orchestrator::config::models::{load_warp_engine_confs, stat_reqs_from};
 use crate::orchestrator::engine::recovery::recover_main;
@@ -21,6 +20,7 @@ use crate::resources::core::manager::ResManager;
 use crate::runtime::sink::act_sink::SinkService;
 use crate::runtime::sink::infrastructure::InfraSinkService;
 use crate::utils::process::PidRec;
+use oml::core::evaluator::query::sql::set_local_sqlite_priority_route;
 use wp_conf::engine::EngineConfig;
 
 #[derive(Deserialize)]

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -1,8 +1,8 @@
 use orion_variate::EnvDict;
+use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use serde::Deserialize;
 
 mod stats_bridge;
 

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -31,38 +31,42 @@ pub fn log_knowdb_init_error(prefix: &str, conf: &Path, err: &impl std::fmt::Deb
     );
 }
 
-#[derive(Clone, Debug)]
-pub struct KnowdbHandler {
-    root: Arc<PathBuf>,
-    conf: Arc<PathBuf>,
-    authority_uri: Arc<String>,
-    initialized: Arc<AtomicBool>,
-    dict: Arc<EnvDict>,
-    local_tables: Arc<Vec<String>>,
-}
-
 #[derive(Deserialize)]
-struct KnowdbTableProbe {
-    name: String,
-    #[serde(default = "default_true")]
-    enabled: bool,
-}
-
-#[derive(Deserialize)]
-struct KnowdbProbe {
+pub(crate) struct KnowdbProviderProbe {
     #[serde(default)]
-    tables: Vec<KnowdbTableProbe>,
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub tables: Vec<String>,
 }
 
-const fn default_true() -> bool {
+#[derive(Deserialize)]
+pub(crate) struct KnowdbTableProbe {
+    pub name: String,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct KnowdbProbe {
+    #[serde(default)]
+    pub provider: Option<KnowdbProviderProbe>,
+    #[serde(default)]
+    pub tables: Vec<KnowdbTableProbe>,
+}
+
+pub(crate) const fn default_true() -> bool {
     true
 }
 
-fn load_local_table_names(conf: &Path) -> Vec<String> {
+pub(crate) fn load_knowdb_probe(conf: &Path) -> Option<KnowdbProbe> {
     let Ok(body) = std::fs::read_to_string(conf) else {
-        return Vec::new();
+        return None;
     };
-    let Ok(probe) = toml::from_str::<KnowdbProbe>(&body) else {
+    toml::from_str::<KnowdbProbe>(&body).ok()
+}
+
+pub(crate) fn load_local_table_names(conf: &Path) -> Vec<String> {
+    let Some(probe) = load_knowdb_probe(conf) else {
         return Vec::new();
     };
     probe
@@ -73,6 +77,36 @@ fn load_local_table_names(conf: &Path) -> Vec<String> {
         .collect()
 }
 
+pub(crate) fn load_provider_table_names(conf: &Path) -> Vec<String> {
+    let Some(probe) = load_knowdb_probe(conf) else {
+        return Vec::new();
+    };
+    probe
+        .provider
+        .map(|provider| provider.tables)
+        .unwrap_or_default()
+}
+
+pub(crate) fn uses_external_provider_only(conf: &Path) -> bool {
+    let Some(probe) = load_knowdb_probe(conf) else {
+        return false;
+    };
+    let provider_only = matches!(
+        probe.provider.and_then(|provider| provider.kind),
+        Some(kind) if kind == "postgres" || kind == "mysql"
+    );
+    provider_only && probe.tables.into_iter().all(|table| !table.enabled)
+}
+
+#[derive(Clone, Debug)]
+pub struct KnowdbHandler {
+    root: Arc<PathBuf>,
+    conf: Arc<PathBuf>,
+    authority_uri: Arc<String>,
+    initialized: Arc<AtomicBool>,
+    dict: Arc<EnvDict>,
+}
+
 impl KnowdbHandler {
     pub fn new(root: &Path, conf: &Path, authority_uri: &str, dict: &EnvDict) -> Self {
         Self {
@@ -81,7 +115,6 @@ impl KnowdbHandler {
             authority_uri: Arc::new(authority_uri.to_string()),
             initialized: Arc::new(AtomicBool::new(false)),
             dict: Arc::new(dict.clone()),
-            local_tables: Arc::new(load_local_table_names(conf)),
         }
     }
 
@@ -112,16 +145,74 @@ impl KnowdbHandler {
             }
         }
     }
+}
 
-    pub fn authority_uri(&self) -> &str {
-        self.authority_uri.as_str()
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_uses_external_provider_only_with_provider_only_config() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let conf = dir.path().join("knowdb.toml");
+        std::fs::write(
+            &conf,
+            r#"
+version = 2
+[provider]
+kind = "postgres"
+connection_uri = "postgres://demo"
+            "#,
+        )
+        .expect("write knowdb");
+
+        assert!(uses_external_provider_only(&conf));
     }
 
-    pub fn local_tables(&self) -> &[String] {
-        self.local_tables.as_slice()
+    #[test]
+    fn test_uses_external_provider_only_false_when_local_tables_exist() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let conf = dir.path().join("knowdb.toml");
+        std::fs::write(
+            &conf,
+            r#"
+version = 2
+[provider]
+kind = "postgres"
+connection_uri = "postgres://demo"
+
+[[tables]]
+name = "local_asset_data"
+            "#,
+        )
+        .expect("write knowdb");
+
+        assert!(!uses_external_provider_only(&conf));
+        assert_eq!(
+            load_local_table_names(&conf),
+            vec!["local_asset_data".to_string()]
+        );
     }
 
-    pub fn has_local_tables(&self) -> bool {
-        !self.local_tables.is_empty()
+    #[test]
+    fn test_load_provider_table_names() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let conf = dir.path().join("knowdb.toml");
+        std::fs::write(
+            &conf,
+            r#"
+version = 2
+[provider]
+kind = "postgres"
+connection_uri = "postgres://demo"
+tables = ["asset_data", "zone"]
+            "#,
+        )
+        .expect("write knowdb");
+
+        assert_eq!(
+            load_provider_table_names(&conf),
+            vec!["asset_data".to_string(), "zone".to_string()]
+        );
     }
 }

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -2,6 +2,7 @@ use orion_variate::EnvDict;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use serde::Deserialize;
 
 mod stats_bridge;
 
@@ -37,6 +38,39 @@ pub struct KnowdbHandler {
     authority_uri: Arc<String>,
     initialized: Arc<AtomicBool>,
     dict: Arc<EnvDict>,
+    local_tables: Arc<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+struct KnowdbTableProbe {
+    name: String,
+    #[serde(default = "default_true")]
+    enabled: bool,
+}
+
+#[derive(Deserialize)]
+struct KnowdbProbe {
+    #[serde(default)]
+    tables: Vec<KnowdbTableProbe>,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+fn load_local_table_names(conf: &Path) -> Vec<String> {
+    let Ok(body) = std::fs::read_to_string(conf) else {
+        return Vec::new();
+    };
+    let Ok(probe) = toml::from_str::<KnowdbProbe>(&body) else {
+        return Vec::new();
+    };
+    probe
+        .tables
+        .into_iter()
+        .filter(|table| table.enabled)
+        .map(|table| table.name)
+        .collect()
 }
 
 impl KnowdbHandler {
@@ -47,6 +81,7 @@ impl KnowdbHandler {
             authority_uri: Arc::new(authority_uri.to_string()),
             initialized: Arc::new(AtomicBool::new(false)),
             dict: Arc::new(dict.clone()),
+            local_tables: Arc::new(load_local_table_names(conf)),
         }
     }
 
@@ -76,5 +111,17 @@ impl KnowdbHandler {
                 );
             }
         }
+    }
+
+    pub fn authority_uri(&self) -> &str {
+        self.authority_uri.as_str()
+    }
+
+    pub fn local_tables(&self) -> &[String] {
+        self.local_tables.as_slice()
+    }
+
+    pub fn has_local_tables(&self) -> bool {
+        !self.local_tables.is_empty()
     }
 }


### PR DESCRIPTION

支持 KnowDB provider 与本地 tables 共存时优先命中 sqlite authority

## 背景

当前 KnowDB 在 `knowdb.toml` 同时包含：

- 外部 provider（如 PostgreSQL / MySQL）
- 本地 `[[tables]]`（CSV -> authority.sqlite）

时，运行时只会激活外部 provider，导致：

- 本地 authority 虽然已配置，但查询不会优先命中 sqlite
- OML SQL 中查询本地表时，仍然发往 PostgreSQL / MySQL
- 如果外部库中没有该表，会直接报错
- `.run/authority.sqlite` 在部分路径下还会被误删

这会让本地静态知识表无法在共存场景下发挥作用。

---

## 问题表现

以示例 `tmp/knowdb_pg_sqlite` 为例：

`knowdb.toml` 同时包含：

- `[provider] kind = "postgres"`
- `[[tables]] name = "local_asset_data"`

对应 OML：

```oml
pg_asset_name: chars = select asset from asset_data where ip = @src_ip;
sqlite_asset_name: chars = select asset from local_asset_data where ip = @src_ip;
sqlite_asset_list = select group_concat(distinct asset) from local_asset_data where ip in (@sip, @dip);
```

期望行为：

- `asset_data` 继续走 PostgreSQL
- `local_asset_data` 优先走本地 sqlite authority

旧行为：

- `local_asset_data` 仍然发往 PostgreSQL
- 典型报错为：

```text
postgres query_named_fields failed: relation "local_asset_data" does not exist
```

---

## 解决方案

本次改动分为两层：

### 1. 启动阶段：即使存在 provider，也先构建本地 authority

在引擎初始化时：

- 如果 `knowdb.toml` 中存在本地 `[[tables]]`
- 无论是否配置了 `[provider]`
- 都先构建 `.run/authority.sqlite`

同时：

- provider 为 `postgres/mysql` 时，不再无条件删除 `authority.sqlite`
- 只有真正需要重建本地 authority 时才清理旧文件

这保证了本地表在运行时始终有可用的 authority 数据源。

### 2. 运行阶段：按表名路由，本地表优先走 sqlite

在 OML SQL evaluator 中增加本地 sqlite 优先路由：

- 启动时收集 `knowdb.toml` 中 `[[tables]]` 的本地表名单
- SQL 执行时解析 `FROM <table>`
- 如果命中本地表名单：
  - 直接走 thread-cloned sqlite authority
- 如果未命中：
  - 继续走当前活动 provider（如 PostgreSQL）

因此实现了：

- 本地表优先 sqlite
- 其他表继续走外部 provider

---

## 同时包含的改动（截至 `1234c99`，包含）

### 1. 增强 OML SQL 表达能力
- 支持 `group_concat(distinct ...)`
- 支持 `where field in (...)`
- 支持 `in(...)` 与 `in (...)`
- 支持 SQL 条件中使用 `@ref` 引用前序 OML 字段

### 2. 空值处理优化
- SQL 聚合无命中返回 `NULL` 时，不再把 `field: null` 写入最终结果
- 如果所有 SQL 动态参数都为 `null`，则直接跳过查询，避免无意义请求和报错

### 3. `take(...)` 语义修复
- `take` 现在可以消费前序 OML 已经写入 `dst` 的字段
- 与 `read` 的上下文可见性保持一致

---

## 主要改动点

### 引擎 / rescue 初始化
- `src/facade/engine.rs`
- `src/facade/rescue.rs`

职责：
- 判断本地 `[[tables]]` 是否存在
- 共存场景下优先构建 authority.sqlite
- 避免 provider 场景误删 authority 文件
- 注册本地 sqlite 优先路由

### KnowDB handler
- `src/knowledge/mod.rs`

职责：
- 记录 authority URI
- 收集本地表名单
- 为运行时 sqlite 优先路由提供上下文

### OML SQL evaluator
- `crates/wp-oml/src/core/evaluator/query/sql.rs`

职责：
- 本地表优先 sqlite 路由
- SQL 全空参数短路
- 保持普通 provider 查询路径不变

### OML 最终结果写入
- `crates/wp-oml/src/core/evaluator/extract/operations/other.rs`

职责：
- 跳过 `Value::Null`，避免输出 `field: null`

### SQL parser
- `crates/wp-oml/src/parser/sql_prm.rs`

职责：
- 支持 `group_concat(distinct ...)`
- 支持 `IN (...)`
- 支持 `@ref`

---

## 验证

已完成验证包括：

### 编译验证
```bash
cargo check -p wp-engine -p wp-oml
```

### 示例验证
在：

- `/Users/zwk/src_code/wp-labs/warp-parse`

执行：

```bash
cargo run --bin wparse --all-features deamon --stat 2 -p --work-root /Users/zwk/src_code/wp-labs/wp-examples_bak/tmp/knowdb_pg_sqlite
```

验证结果：

- `asset_data` 继续走 PostgreSQL
- `local_asset_data` 已优先命中 sqlite authority

输出文件中已出现：

```json
{
  "src_ip":"10.0.220.200",
  "dist_ip":"10.0.220.201",
  "pg_asset_name":"香港监控服务主机",
  "sqlite_asset_name":"1香港监控服务主机",
  "sqlite_asset_list":"1香港监控服务主机,1广东监控服务主机"
}
```

---

## 关联 Issue

- #96
